### PR TITLE
Fix code scanning alert no. 686: Multiplication result converted to larger type

### DIFF
--- a/ivsr_sdk/src/smart_patch.cpp
+++ b/ivsr_sdk/src/smart_patch.cpp
@@ -101,7 +101,7 @@ void fill_image(std::vector<std::vector<int>> patchCorners, char* imgBuf, \
     int img_sN = iC * iH * iW;
     int img_sB = iN * iC * iH * iW;
     
-    size_t outputpixels = iB * iN * iC * iH * iW;
+    size_t outputpixels = static_cast<size_t>(iB) * iN * iC * iH * iW;
     int * pixelCounter = new int[outputpixels]();
 
     float * img_ptr =(float *)imgBuf;


### PR DESCRIPTION
Fixes [https://github.com/OpenVisualCloud/iVSR/security/code-scanning/686](https://github.com/OpenVisualCloud/iVSR/security/code-scanning/686)

To fix the problem, we need to ensure that the multiplication is performed using the larger type (`size_t`) to avoid overflow. This can be achieved by casting one of the operands to `size_t` before performing the multiplication. This way, the multiplication will be done using the larger type, and the risk of overflow will be mitigated.

We will modify the code on line 104 to cast the first operand (`iB`) to `size_t` before performing the multiplication.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
